### PR TITLE
Add rating and rating cout

### DIFF
--- a/entity/entity.go
+++ b/entity/entity.go
@@ -205,6 +205,8 @@ type Item struct {
 			} `json:",omitempty"`
 			MerchantInfo *struct {
 				DefaultShippingCountry string
+				FeedbackCount          int
+				FeedbackRating         float64
 				ID                     string `json:"Id"`
 				Name                   string
 			} `json:",omitempty"`


### PR DESCRIPTION
Amazon PAAPI started returning rating info for selected clients. When they activate such feature, it comes via these two properties in their GetItems responses.

Sample:

```
{
  "ItemsResult": {
    "Items": [
      {
        "Offers": {
          "Listings": [
            {
              "MerchantInfo": {
                "FeedbackCount": 385,
                "FeedbackRating": 4.68,
                "Id": "ATVPDKIKX0DER",
                "Name": "Amazon.com"
              }
           }
         ]
      }
    ]
  }
}
```