### PR TITLE
fix VariationAttributes type location

### DIFF
--- a/entity/entity.go
+++ b/entity/entity.go
@@ -182,9 +182,9 @@ type Item struct {
 				Currency      string
 			}
 		} `json:",omitempty"`
-		VariationAttributes []VariationAttribute `json:",omitempty"`
 	}
-	Offers *struct {
+	VariationAttributes []VariationAttribute `json:",omitempty"`
+	Offers              *struct {
 		Listings *[]struct {
 			Availability *struct {
 				MaxOrderQuantity int


### PR DESCRIPTION
Hey mate!
Thanks for sharing this SDK - it is very useful as I don't need to duplicate all the code for interacting with Amazon PA API in my project.
However, I've noted one issue that blocks me from getting VariationAttributes data

`q := query.NewGetVariations(
		client.Marketplace(),
		client.PartnerTag(),
		client.PartnerType(),
	).ASIN(productID).
		EnableImages().
		EnableItemInfo().
		EnableOffers().
		EnableVariationSummary().
		ParentASIN()`

I believe the issue is that the  entity/entity.go type is not compatible with Amazon PA API response structure.
Current type VariationAttributes type location:
Item.ItemInfo.VariationAttributes
GetVariation operation VariationAttributes type location:
Item.VariationAttributes
Please, see:
https://webservices.amazon.com/paapi5/documentation/get-variations.html