### PR TITLE
Add Ireland Region to Locale Maps

### DIFF
--- a/marketplace.go
+++ b/marketplace.go
@@ -20,6 +20,7 @@ const (
 	LocaleFrance                                    //France
 	LocaleGermany                                   //Germany
 	LocaleIndia                                     //India
+	LocaleIreland                                   //Ireland
 	LocaleItaly                                     //Italy
 	LocaleJapan                                     //Japan
 	LocaleMexico                                    //Mexico
@@ -44,6 +45,7 @@ var marketplaceMap = map[MarketplaceEnum]string{
 	LocaleFrance:             "www.amazon.fr",     //France
 	LocaleGermany:            "www.amazon.de",     //Germany
 	LocaleIndia:              "www.amazon.in",     //India
+	LocaleIreland:            "www.amazon.ie",     //Ireland
 	LocaleItaly:              "www.amazon.it",     //Italy
 	LocaleJapan:              "www.amazon.co.jp",  //Japan
 	LocaleMexico:             "www.amazon.com.mx", //Mexico
@@ -80,6 +82,7 @@ var hostMap = map[MarketplaceEnum]string{
 	LocaleUnitedArabEmirates: "webservices.amazon.ae",     //United Arab Emirates
 	LocaleUnitedKingdom:      "webservices.amazon.co.uk",  //United Kingdom
 	LocaleUnitedStates:       "webservices.amazon.com",    //United States
+	LocaleIreland:            "webservices.amazon.ie",     //Ireland
 }
 
 var regionMap = map[MarketplaceEnum]string{
@@ -90,6 +93,7 @@ var regionMap = map[MarketplaceEnum]string{
 	LocaleFrance:             "eu-west-1", //France
 	LocaleGermany:            "eu-west-1", //Germany
 	LocaleIndia:              "eu-west-1", //India
+	LocaleIreland:            "eu-west-1", //Ireland
 	LocaleItaly:              "eu-west-1", //Italy
 	LocaleJapan:              "us-west-2", //Japan
 	LocaleMexico:             "us-east-1", //Mexico
@@ -113,6 +117,7 @@ var languageMap = map[MarketplaceEnum]string{
 	LocaleFrance:             "fr_FR", //France
 	LocaleGermany:            "de_DE", //Germany
 	LocaleIndia:              "en_IN", //India
+	LocaleIreland:            "en_IE", //Ireland
 	LocaleItaly:              "it_IT", //Italy
 	LocaleJapan:              "ja_JP", //Japan
 	LocaleMexico:             "es_MX", //Mexico

--- a/marketplace_test.go
+++ b/marketplace_test.go
@@ -18,6 +18,7 @@ func TestMarketplace(t *testing.T) {
 		{name: "www.amazon.fr", marketplace: LocaleFrance, str: "www.amazon.fr", hostName: "webservices.amazon.fr", region: "eu-west-1", language: "fr_FR"},
 		{name: "www.amazon.de", marketplace: LocaleGermany, str: "www.amazon.de", hostName: "webservices.amazon.de", region: "eu-west-1", language: "de_DE"},
 		{name: "www.amazon.in", marketplace: LocaleIndia, str: "www.amazon.in", hostName: "webservices.amazon.in", region: "eu-west-1", language: "en_IN"},
+		{name: "www.amazon.ie", marketplace: LocaleIreland, str: "www.amazon.ie", hostName: "webservices.amazon.ie", region: "eu-west-1", language: "en_IE"},
 		{name: "www.amazon.it", marketplace: LocaleItaly, str: "www.amazon.it", hostName: "webservices.amazon.it", region: "eu-west-1", language: "it_IT"},
 		{name: "www.amazon.co.jp", marketplace: LocaleJapan, str: "www.amazon.co.jp", hostName: "webservices.amazon.co.jp", region: "us-west-2", language: "ja_JP"},
 		{name: "www.amazon.com.mx", marketplace: LocaleMexico, str: "www.amazon.com.mx", hostName: "webservices.amazon.com.mx", region: "us-east-1", language: "es_MX"},


### PR DESCRIPTION
Upon attempting to lookup product data for amazon.ie products I noticed that the region was missing from the locales map. This adds it in - I have tested this against PAAPI lookups with successful responses. 