### PR TITLE
Change PercentClaimed field of OffersV2 to int type

### DIFF
--- a/entity/entity.go
+++ b/entity/entity.go
@@ -274,7 +274,7 @@ type Item struct {
 				Badge                             string `json:",omitempty"`
 				EarlyAccessDurationInMilliseconds int64  `json:",omitempty"`
 				EndTime                           string `json:",omitempty"`
-				PercentClaimed                    string `json:",omitempty"`
+				PercentClaimed                    int    `json:",omitempty"`
 				StartTime                         string `json:",omitempty"`
 			} `json:",omitempty"`
 			IsBuyboxWinner bool


### PR DESCRIPTION
There is a misprint in [AWS OffersV2 documentation](https://webservices.amazon.com/paapi5/documentation/offersV2.html#dealdetails) that states the PercentClaimed field is a string, however the payload json response returns an int type.
