### PR TITLE
Safe Creators API migration fixes (derived from #49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ The library keeps several legacy knobs for source compatibility, but the Creator
 | `PartnerType` (`Associates`) | Explicit body parameter | Ignored. Partner type is implicit |
 | `Merchant` | Offer filtering selector | Ignored |
 | `OfferCount` | Offer summary limiter | Ignored |
-| `EnableVariationSummary()` | Requested variation summary resource | No-op (resource is not exposed) |
 
 ### Marketplace routing precedence
 

--- a/entity/entity.go
+++ b/entity/entity.go
@@ -109,6 +109,7 @@ type Item struct {
 			SalesRank        *int      `json:",omitempty"`
 			Ancestor         *Ancestor `json:",omitempty"`
 			WebsiteSalesRank *struct {
+				Id              string `json:"id,omitempty"`
 				DisplayName     string
 				ContextFreeName string
 				SalesRank       int
@@ -120,11 +121,13 @@ type Item struct {
 			Large  *Image `json:",omitempty"`
 			Medium *Image `json:",omitempty"`
 			Small  *Image `json:",omitempty"`
+			HiRes  *Image `json:"hiRes,omitempty"`
 		} `json:",omitempty"`
 		Variants []*struct {
 			Large  *Image `json:",omitempty"`
 			Medium *Image `json:",omitempty"`
 			Small  *Image `json:",omitempty"`
+			HiRes  *Image `json:"hiRes,omitempty"`
 		} `json:",omitempty"`
 	} `json:",omitempty"`
 	ItemInfo *struct {
@@ -295,8 +298,8 @@ type Item struct {
 					Percentage int
 				} `json:",omitempty"`
 			} `json:",omitempty"`
-			Type       string `json:",omitempty"`
-			ViolateMAP bool
+			Type        string `json:",omitempty"`
+			ViolatesMAP bool   `json:"violatesMAP,omitempty"`
 		} `json:",omitempty"`
 	} `json:",omitempty"`
 }
@@ -318,6 +321,7 @@ type Price struct {
 
 type VariationDimension struct {
 	DisplayName string
+	Locale      string `json:",omitempty"`
 	Name        string
 	Values      []string
 }
@@ -329,7 +333,7 @@ type Response struct {
 	} `json:",omitempty"`
 	ItemsResult *struct {
 		Items []Item `json:",omitempty"`
-	} `json:",omitempty"`
+	} `json:"itemResults,omitempty"`
 	SearchResult *struct {
 		Items             []Item `json:",omitempty"`
 		SearchRefinements *struct {
@@ -364,6 +368,7 @@ type Response struct {
 			DisplayName     string
 			ContextFreeName string
 			IsRoot          bool
+			SalesRank       *int `json:",omitempty"`
 		} `json:",omitempty"`
 	} `json:",omitempty"`
 }

--- a/entity/entity_test.go
+++ b/entity/entity_test.go
@@ -1,0 +1,160 @@
+package entity
+
+import "testing"
+
+func TestDecodeResponseItemResultsAndCreatorsFields(t *testing.T) {
+	body := []byte(`{
+  "itemResults": {
+    "items": [
+      {
+        "asin": "A1",
+        "images": {
+          "primary": {
+            "small": {"url": "https://example/s.jpg", "height": 75, "width": 75},
+            "hiRes": {"url": "https://example/hi.jpg", "height": 1000, "width": 1000}
+          },
+          "variants": [
+            {
+              "small": {"url": "https://example/vs.jpg", "height": 75, "width": 75},
+              "hiRes": {"url": "https://example/vh.jpg", "height": 1000, "width": 1000}
+            }
+          ]
+        },
+        "browseNodeInfo": {
+          "browseNodes": [
+            {
+              "id": "123",
+              "displayName": "Books",
+              "contextFreeName": "Books",
+              "websiteSalesRank": {
+                "id": "999",
+                "displayName": "Books",
+                "contextFreeName": "Books",
+                "salesRank": 7
+              }
+            }
+          ]
+        },
+        "offersV2": {
+          "listings": [
+            {
+              "type": "New",
+              "violatesMAP": true
+            }
+          ]
+        }
+      }
+    ]
+  }
+}`)
+
+	resp, err := DecodeResponse(body)
+	if err != nil {
+		t.Fatalf("DecodeResponse: %+v", err)
+	}
+	if resp.ItemsResult == nil {
+		t.Fatal("ItemsResult is nil")
+	}
+	if got, want := len(resp.ItemsResult.Items), 1; got != want {
+		t.Fatalf("len(ItemsResult.Items) = %d, want %d", got, want)
+	}
+
+	item := resp.ItemsResult.Items[0]
+	if item.Images == nil || item.Images.Primary == nil || item.Images.Primary.HiRes == nil {
+		t.Fatal("Images.Primary.HiRes is nil")
+	}
+	if got, want := item.Images.Primary.HiRes.URL, "https://example/hi.jpg"; got != want {
+		t.Errorf("Images.Primary.HiRes.URL = %q, want %q", got, want)
+	}
+	if item.Images.Variants == nil || len(item.Images.Variants) != 1 || item.Images.Variants[0].HiRes == nil {
+		t.Fatal("Images.Variants[0].HiRes is nil")
+	}
+	if got, want := item.Images.Variants[0].HiRes.URL, "https://example/vh.jpg"; got != want {
+		t.Errorf("Images.Variants[0].HiRes.URL = %q, want %q", got, want)
+	}
+
+	if item.BrowseNodeInfo == nil || len(item.BrowseNodeInfo.BrowseNodes) != 1 || item.BrowseNodeInfo.BrowseNodes[0].WebsiteSalesRank == nil {
+		t.Fatal("BrowseNodeInfo.BrowseNodes[0].WebsiteSalesRank is nil")
+	}
+	if got, want := item.BrowseNodeInfo.BrowseNodes[0].WebsiteSalesRank.Id, "999"; got != want {
+		t.Errorf("WebsiteSalesRank.Id = %q, want %q", got, want)
+	}
+
+	if item.OffersV2 == nil || item.OffersV2.Listings == nil || len(*item.OffersV2.Listings) != 1 {
+		t.Fatal("OffersV2.Listings is empty")
+	}
+	if !(*item.OffersV2.Listings)[0].ViolatesMAP {
+		t.Errorf("ViolatesMAP = false, want true")
+	}
+}
+
+func TestDecodeResponseVariationSummaryAndBrowseSalesRank(t *testing.T) {
+	body := []byte(`{
+  "variationsResult": {
+    "variationSummary": {
+      "pageCount": 2,
+      "variationCount": 13,
+      "price": {
+        "highestPrice": {"amount": 30.87, "currency": "GBP", "displayAmount": "GBP 30.87"},
+        "lowestPrice": {"amount": 17.03, "currency": "GBP", "displayAmount": "GBP 17.03"}
+      },
+      "variationDimensions": [
+        {
+          "displayName": "Color",
+          "locale": "en_GB",
+          "name": "color_name",
+          "values": ["Red", "Blue"]
+        }
+      ]
+    }
+  },
+  "browseNodesResult": {
+    "browseNodes": [
+      {
+        "id": "283155",
+        "displayName": "Books",
+        "contextFreeName": "Books",
+        "isRoot": true,
+        "salesRank": 11
+      }
+    ]
+  }
+}`)
+
+	resp, err := DecodeResponse(body)
+	if err != nil {
+		t.Fatalf("DecodeResponse: %+v", err)
+	}
+	if resp.VariationsResult == nil || resp.VariationsResult.VariationSummary == nil {
+		t.Fatal("VariationsResult.VariationSummary is nil")
+	}
+	vs := resp.VariationsResult.VariationSummary
+	if got, want := vs.PageCount, 2; got != want {
+		t.Errorf("PageCount = %d, want %d", got, want)
+	}
+	if got, want := vs.VariationCount, 13; got != want {
+		t.Errorf("VariationCount = %d, want %d", got, want)
+	}
+	if vs.Price == nil || vs.Price.HighestPrice == nil || vs.Price.LowestPrice == nil {
+		t.Fatal("VariationSummary.Price is nil")
+	}
+	if got, want := vs.Price.HighestPrice.Currency, "GBP"; got != want {
+		t.Errorf("HighestPrice.Currency = %q, want %q", got, want)
+	}
+	if got, want := len(vs.VariationDimensions), 1; got != want {
+		t.Fatalf("len(VariationDimensions) = %d, want %d", got, want)
+	}
+	if got, want := vs.VariationDimensions[0].Locale, "en_GB"; got != want {
+		t.Errorf("VariationDimensions[0].Locale = %q, want %q", got, want)
+	}
+
+	if resp.BrowseNodesResult == nil || len(resp.BrowseNodesResult.BrowseNodes) != 1 {
+		t.Fatal("BrowseNodesResult.BrowseNodes is empty")
+	}
+	if resp.BrowseNodesResult.BrowseNodes[0].SalesRank == nil {
+		t.Fatal("BrowseNodes[0].SalesRank is nil")
+	}
+	if got, want := *resp.BrowseNodesResult.BrowseNodes[0].SalesRank, 11; got != want {
+		t.Errorf("BrowseNodes[0].SalesRank = %d, want %d", got, want)
+	}
+}

--- a/query/getvariations_test.go
+++ b/query/getvariations_test.go
@@ -92,7 +92,7 @@ func TestResourcesInGetVariations(t *testing.T) {
 		{q: NewGetVariations("", "", "").EnableItemInfo(), str: `{"resources":["itemInfo.byLineInfo","itemInfo.contentInfo","itemInfo.contentRating","itemInfo.classifications","itemInfo.externalIds","itemInfo.features","itemInfo.manufactureInfo","itemInfo.productInfo","itemInfo.technicalInfo","itemInfo.title","itemInfo.tradeInInfo"]}`},
 		{q: NewGetVariations("", "", "").EnableOffers(), str: `{"resources":["offersV2.listings.availability","offersV2.listings.condition","offersV2.listings.dealDetails","offersV2.listings.isBuyBoxWinner","offersV2.listings.loyaltyPoints","offersV2.listings.merchantInfo","offersV2.listings.price","offersV2.listings.type"]}`},
 		{q: NewGetVariations("", "", "").EnableOffersV2(), str: `{"resources":["offersV2.listings.availability","offersV2.listings.condition","offersV2.listings.dealDetails","offersV2.listings.isBuyBoxWinner","offersV2.listings.loyaltyPoints","offersV2.listings.merchantInfo","offersV2.listings.price","offersV2.listings.type"]}`},
-		{q: NewGetVariations("", "", "").EnableVariationSummary(), str: `{}`},
+		{q: NewGetVariations("", "", "").EnableVariationSummary(), str: `{"resources":["variationSummary.price.highestPrice","variationSummary.price.lowestPrice","variationSummary.variationDimension"]}`},
 	}
 
 	for _, tc := range testCases {

--- a/query/query.go
+++ b/query/query.go
@@ -145,12 +145,10 @@ func (q *Query) BrowseNodes() *Query {
 	return q
 }
 
-// VariationSummary selects the VariationSummary resource.
-//
-// Deprecated: the Creators API does not expose a VariationSummary resource.
-// Calls to this method are now no-ops and the response will not contain a
-// VariationSummary block. Retained so existing call sites compile.
+// VariationSummary sets the resource of VariationSummary. The Creators API
+// returns this block under VariationsResult.VariationSummary.
 func (q *Query) VariationSummary() *Query {
+	q.enableResources[resourceVariationSummary] = true
 	return q
 }
 

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -140,8 +140,7 @@ func TestResources(t *testing.T) {
 		{q: empty.With().ParentASIN(), str: `{"resources":["parentASIN"]}`},
 		{q: empty.With().CustomerReviews(), str: `{"resources":["customerReviews.count","customerReviews.starRating"]}`},
 		{q: empty.With().BrowseNodes(), str: `{"resources":["browseNodes.ancestor","browseNodes.children"]}`},
-		// VariationSummary is no longer exposed by the Creators API.
-		{q: empty.With().VariationSummary(), str: `{}`},
+		{q: empty.With().VariationSummary(), str: `{"resources":["variationSummary.price.highestPrice","variationSummary.price.lowestPrice","variationSummary.variationDimension"]}`},
 	}
 
 	for _, tc := range testCases {

--- a/query/resources.go
+++ b/query/resources.go
@@ -11,6 +11,7 @@ const (
 	resourceParentASIN                            //ParentASIN resource
 	resourceCustomerReviews                       //CustomerReviews resource
 	resourceBrowseNodes                           //BrowseNodes resource
+	resourceVariationSummary                      //VariationSummary resource
 )
 
 // Resource string values match the Amazon Creators API enum values
@@ -77,6 +78,12 @@ var (
 		"browseNodes.ancestor",
 		"browseNodes.children",
 	}
+	//VariationSummary resource
+	resourcesVariationSummary = []string{
+		"variationSummary.price.highestPrice",
+		"variationSummary.price.lowestPrice",
+		"variationSummary.variationDimension",
+	}
 
 	resourcesMap = map[resource][]string{
 		resourceBrowseNodeInfo:    resourcesBrowseNodeInfo,
@@ -87,6 +94,7 @@ var (
 		resourceParentASIN:        resourcesParentASIN,
 		resourceCustomerReviews:   resourcesCustomerReviews,
 		resourceBrowseNodes:       resourcesBrowseNodes,
+		resourceVariationSummary:  resourcesVariationSummary,
 	}
 )
 


### PR DESCRIPTION
## Summary
Derived from #49. This PR intentionally extracts only the low-risk migration-compatible subset (PR-A).

## Scope
- [x] Restore VariationSummary resource wiring.
- [x] Update query tests for VariationSummary resources.
- [x] Keep additive entity decode fixes aligned with current Creators API payloads.
- [x] Decode itemResults via explicit JSON tag compatibility.
- [x] Standardize on ViolatesMAP only (no ViolateMAP alias).
- [x] Remove outdated README note that said EnableVariationSummary was a no-op.
- [x] Add focused entity decode regression tests.

## Out of Scope (PR-B)
- [ ] Behavior/shape contractions.
- [ ] Resource-scope reductions.
- [ ] Test rewrites that change behavior expectations.

## Validation
- [x] task test
