### PR TITLE
Remove unused entity fields

### DIFF
--- a/entity/entity.go
+++ b/entity/entity.go
@@ -90,9 +90,11 @@ type VariationAttribute struct {
 }
 
 type Item struct {
-	ASIN            string
-	ParentASIN      string
-	DetailPageURL   string
+	ASIN          string
+	ParentASIN    string
+	DetailPageURL string
+	// Deprecated: not described in current Creators API documentation; retained for JSON compatibility.
+	Score           *float64 `json:",omitempty"`
 	CustomerReviews *struct {
 		Count      *int `json:",omitempty"`
 		StarRating *struct {
@@ -101,12 +103,16 @@ type Item struct {
 	} `json:",omitempty"`
 	BrowseNodeInfo *struct {
 		BrowseNodes []struct {
-			Id               string
-			DisplayName      string
-			ContextFreeName  string
-			IsRoot           bool
+			Id              string
+			DisplayName     string
+			ContextFreeName string
+			IsRoot          bool
+			// Deprecated: not described in current Creators API documentation; retained for JSON compatibility.
+			SalesRank        *int      `json:",omitempty"`
 			Ancestor         *Ancestor `json:",omitempty"`
 			WebsiteSalesRank *struct {
+				// Deprecated: not described in current Creators API documentation; retained for JSON compatibility.
+				Id              string `json:"id,omitempty"`
 				DisplayName     string
 				ContextFreeName string
 				SalesRank       int
@@ -118,11 +124,15 @@ type Item struct {
 			Large  *Image `json:",omitempty"`
 			Medium *Image `json:",omitempty"`
 			Small  *Image `json:",omitempty"`
+			// Deprecated: high-resolution image keys are not documented resource paths for Creators API; retained for JSON compatibility.
+			HiRes *Image `json:"hiRes,omitempty"`
 		} `json:",omitempty"`
 		Variants []*struct {
 			Large  *Image `json:",omitempty"`
 			Medium *Image `json:",omitempty"`
 			Small  *Image `json:",omitempty"`
+			// Deprecated: high-resolution image keys are not documented resource paths for Creators API; retained for JSON compatibility.
+			HiRes *Image `json:"hiRes,omitempty"`
 		} `json:",omitempty"`
 	} `json:",omitempty"`
 	ItemInfo *struct {
@@ -316,8 +326,10 @@ type Price struct {
 
 type VariationDimension struct {
 	DisplayName string
-	Name        string
-	Values      []string
+	// Deprecated: not described in current Creators API documentation; retained for JSON compatibility.
+	Locale string `json:",omitempty"`
+	Name   string
+	Values []string
 }
 
 type Response struct {
@@ -327,7 +339,7 @@ type Response struct {
 	} `json:",omitempty"`
 	ItemsResult *struct {
 		Items []Item `json:",omitempty"`
-	} `json:"itemResults,omitempty"`
+	} `json:"itemsResult,omitempty"`
 	SearchResult *struct {
 		Items             []Item `json:",omitempty"`
 		SearchRefinements *struct {
@@ -362,6 +374,8 @@ type Response struct {
 			DisplayName     string
 			ContextFreeName string
 			IsRoot          bool
+			// Deprecated: not described in current Creators API documentation; retained for JSON compatibility.
+			SalesRank *int `json:",omitempty"`
 		} `json:",omitempty"`
 	} `json:",omitempty"`
 }

--- a/entity/entity.go
+++ b/entity/entity.go
@@ -93,7 +93,6 @@ type Item struct {
 	ASIN            string
 	ParentASIN      string
 	DetailPageURL   string
-	Score           *float64 `json:",omitempty"`
 	CustomerReviews *struct {
 		Count      *int `json:",omitempty"`
 		StarRating *struct {
@@ -106,10 +105,8 @@ type Item struct {
 			DisplayName      string
 			ContextFreeName  string
 			IsRoot           bool
-			SalesRank        *int      `json:",omitempty"`
 			Ancestor         *Ancestor `json:",omitempty"`
 			WebsiteSalesRank *struct {
-				Id              string `json:"id,omitempty"`
 				DisplayName     string
 				ContextFreeName string
 				SalesRank       int
@@ -121,13 +118,11 @@ type Item struct {
 			Large  *Image `json:",omitempty"`
 			Medium *Image `json:",omitempty"`
 			Small  *Image `json:",omitempty"`
-			HiRes  *Image `json:"hiRes,omitempty"`
 		} `json:",omitempty"`
 		Variants []*struct {
 			Large  *Image `json:",omitempty"`
 			Medium *Image `json:",omitempty"`
 			Small  *Image `json:",omitempty"`
-			HiRes  *Image `json:"hiRes,omitempty"`
 		} `json:",omitempty"`
 	} `json:",omitempty"`
 	ItemInfo *struct {
@@ -321,7 +316,6 @@ type Price struct {
 
 type VariationDimension struct {
 	DisplayName string
-	Locale      string `json:",omitempty"`
 	Name        string
 	Values      []string
 }
@@ -368,7 +362,6 @@ type Response struct {
 			DisplayName     string
 			ContextFreeName string
 			IsRoot          bool
-			SalesRank       *int `json:",omitempty"`
 		} `json:",omitempty"`
 	} `json:",omitempty"`
 }

--- a/entity/entity_test.go
+++ b/entity/entity_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestDecodeResponseItemResultsOffersV2AndBrowseNodeInfo(t *testing.T) {
 	body := []byte(`{
-  "itemResults": {
+  "itemsResult": {
     "items": [
       {
         "asin": "A1",
@@ -87,6 +87,71 @@ func TestDecodeResponseItemResultsOffersV2AndBrowseNodeInfo(t *testing.T) {
 	}
 }
 
+// Deprecated fields are kept on exported structs for source compatibility; they
+// must still decode when present in arbitrary JSON.
+func TestDeprecatedFieldsStillDecode(t *testing.T) {
+	body := []byte(`{
+  "itemsResult": {
+    "items": [{
+      "asin": "DEP1",
+      "score": 0.91,
+      "images": {
+        "primary": {"hiRes": {"url": "https://example/hi.png", "height": 10, "width": 10}},
+        "variants": [{"hiRes": {"url": "https://example/vhi.png", "height": 11, "width": 11}}]
+      },
+      "browseNodeInfo": {
+        "browseNodes": [{
+          "id": "bn1",
+          "displayName": "Cat",
+          "contextFreeName": "Cat",
+          "salesRank": 99,
+          "websiteSalesRank": {
+            "id": "wsr-id",
+            "displayName": "SiteCat",
+            "contextFreeName": "SiteCat",
+            "salesRank": 5
+          }
+        }]
+      }
+    }]
+  },
+  "browseNodesResult": {
+    "browseNodes": [{
+      "id": "283155",
+      "displayName": "Books",
+      "contextFreeName": "Books",
+      "isRoot": true,
+      "salesRank": 11
+    }]
+  }
+}`)
+	resp, err := DecodeResponse(body)
+	if err != nil {
+		t.Fatalf("DecodeResponse: %+v", err)
+	}
+	it := resp.ItemsResult.Items[0]
+	if it.Score == nil || *it.Score != 0.91 {
+		t.Fatalf("Score = %v, want 0.91", it.Score)
+	}
+	if it.Images.Primary.HiRes == nil || it.Images.Primary.HiRes.URL != "https://example/hi.png" {
+		t.Fatal("deprecated HiRes primary not decoded")
+	}
+	if len(it.Images.Variants) != 1 || it.Images.Variants[0].HiRes == nil {
+		t.Fatal("deprecated HiRes variant not decoded")
+	}
+	bn := it.BrowseNodeInfo.BrowseNodes[0]
+	if bn.SalesRank == nil || *bn.SalesRank != 99 {
+		t.Fatalf("browseNodes[].salesRank = %v, want 99", bn.SalesRank)
+	}
+	if bn.WebsiteSalesRank.Id != "wsr-id" || bn.WebsiteSalesRank.SalesRank != 5 {
+		t.Fatalf("websiteSalesRank: %+v", bn.WebsiteSalesRank)
+	}
+	if len(resp.BrowseNodesResult.BrowseNodes) != 1 || resp.BrowseNodesResult.BrowseNodes[0].SalesRank == nil ||
+		*resp.BrowseNodesResult.BrowseNodes[0].SalesRank != 11 {
+		t.Fatalf("browseNodesResult browseNodes[].salesRank decode failed")
+	}
+}
+
 func TestDecodeResponseVariationSummary(t *testing.T) {
 	body := []byte(`{
   "variationsResult": {
@@ -100,6 +165,7 @@ func TestDecodeResponseVariationSummary(t *testing.T) {
       "variationDimensions": [
         {
           "displayName": "Color",
+          "locale": "en_GB",
           "name": "color_name",
           "values": ["Red", "Blue"]
         }
@@ -133,5 +199,8 @@ func TestDecodeResponseVariationSummary(t *testing.T) {
 	}
 	if got, want := vs.VariationDimensions[0].Name, "color_name"; got != want {
 		t.Errorf("VariationDimensions[0].Name = %q, want %q", got, want)
+	}
+	if got, want := vs.VariationDimensions[0].Locale, "en_GB"; got != want {
+		t.Errorf("VariationDimensions[0].Locale = %q, want %q", got, want)
 	}
 }

--- a/entity/entity_test.go
+++ b/entity/entity_test.go
@@ -2,7 +2,7 @@ package entity
 
 import "testing"
 
-func TestDecodeResponseItemResultsAndCreatorsFields(t *testing.T) {
+func TestDecodeResponseItemResultsOffersV2AndBrowseNodeInfo(t *testing.T) {
 	body := []byte(`{
   "itemResults": {
     "items": [
@@ -11,12 +11,12 @@ func TestDecodeResponseItemResultsAndCreatorsFields(t *testing.T) {
         "images": {
           "primary": {
             "small": {"url": "https://example/s.jpg", "height": 75, "width": 75},
-            "hiRes": {"url": "https://example/hi.jpg", "height": 1000, "width": 1000}
+            "large": {"url": "https://example/l.jpg", "height": 500, "width": 500}
           },
           "variants": [
             {
               "small": {"url": "https://example/vs.jpg", "height": 75, "width": 75},
-              "hiRes": {"url": "https://example/vh.jpg", "height": 1000, "width": 1000}
+              "large": {"url": "https://example/vl.jpg", "height": 500, "width": 500}
             }
           ]
         },
@@ -27,7 +27,6 @@ func TestDecodeResponseItemResultsAndCreatorsFields(t *testing.T) {
               "displayName": "Books",
               "contextFreeName": "Books",
               "websiteSalesRank": {
-                "id": "999",
                 "displayName": "Books",
                 "contextFreeName": "Books",
                 "salesRank": 7
@@ -60,24 +59,24 @@ func TestDecodeResponseItemResultsAndCreatorsFields(t *testing.T) {
 	}
 
 	item := resp.ItemsResult.Items[0]
-	if item.Images == nil || item.Images.Primary == nil || item.Images.Primary.HiRes == nil {
-		t.Fatal("Images.Primary.HiRes is nil")
+	if item.Images == nil || item.Images.Primary == nil || item.Images.Primary.Large == nil {
+		t.Fatal("Images.Primary.Large is nil")
 	}
-	if got, want := item.Images.Primary.HiRes.URL, "https://example/hi.jpg"; got != want {
-		t.Errorf("Images.Primary.HiRes.URL = %q, want %q", got, want)
+	if got, want := item.Images.Primary.Large.URL, "https://example/l.jpg"; got != want {
+		t.Errorf("Images.Primary.Large.URL = %q, want %q", got, want)
 	}
-	if item.Images.Variants == nil || len(item.Images.Variants) != 1 || item.Images.Variants[0].HiRes == nil {
-		t.Fatal("Images.Variants[0].HiRes is nil")
+	if item.Images.Variants == nil || len(item.Images.Variants) != 1 || item.Images.Variants[0].Large == nil {
+		t.Fatal("Images.Variants[0].Large is nil")
 	}
-	if got, want := item.Images.Variants[0].HiRes.URL, "https://example/vh.jpg"; got != want {
-		t.Errorf("Images.Variants[0].HiRes.URL = %q, want %q", got, want)
+	if got, want := item.Images.Variants[0].Large.URL, "https://example/vl.jpg"; got != want {
+		t.Errorf("Images.Variants[0].Large.URL = %q, want %q", got, want)
 	}
 
 	if item.BrowseNodeInfo == nil || len(item.BrowseNodeInfo.BrowseNodes) != 1 || item.BrowseNodeInfo.BrowseNodes[0].WebsiteSalesRank == nil {
 		t.Fatal("BrowseNodeInfo.BrowseNodes[0].WebsiteSalesRank is nil")
 	}
-	if got, want := item.BrowseNodeInfo.BrowseNodes[0].WebsiteSalesRank.Id, "999"; got != want {
-		t.Errorf("WebsiteSalesRank.Id = %q, want %q", got, want)
+	if got, want := item.BrowseNodeInfo.BrowseNodes[0].WebsiteSalesRank.SalesRank, 7; got != want {
+		t.Errorf("WebsiteSalesRank.SalesRank = %d, want %d", got, want)
 	}
 
 	if item.OffersV2 == nil || item.OffersV2.Listings == nil || len(*item.OffersV2.Listings) != 1 {
@@ -88,7 +87,7 @@ func TestDecodeResponseItemResultsAndCreatorsFields(t *testing.T) {
 	}
 }
 
-func TestDecodeResponseVariationSummaryAndBrowseSalesRank(t *testing.T) {
+func TestDecodeResponseVariationSummary(t *testing.T) {
 	body := []byte(`{
   "variationsResult": {
     "variationSummary": {
@@ -101,23 +100,11 @@ func TestDecodeResponseVariationSummaryAndBrowseSalesRank(t *testing.T) {
       "variationDimensions": [
         {
           "displayName": "Color",
-          "locale": "en_GB",
           "name": "color_name",
           "values": ["Red", "Blue"]
         }
       ]
     }
-  },
-  "browseNodesResult": {
-    "browseNodes": [
-      {
-        "id": "283155",
-        "displayName": "Books",
-        "contextFreeName": "Books",
-        "isRoot": true,
-        "salesRank": 11
-      }
-    ]
   }
 }`)
 
@@ -144,17 +131,7 @@ func TestDecodeResponseVariationSummaryAndBrowseSalesRank(t *testing.T) {
 	if got, want := len(vs.VariationDimensions), 1; got != want {
 		t.Fatalf("len(VariationDimensions) = %d, want %d", got, want)
 	}
-	if got, want := vs.VariationDimensions[0].Locale, "en_GB"; got != want {
-		t.Errorf("VariationDimensions[0].Locale = %q, want %q", got, want)
-	}
-
-	if resp.BrowseNodesResult == nil || len(resp.BrowseNodesResult.BrowseNodes) != 1 {
-		t.Fatal("BrowseNodesResult.BrowseNodes is empty")
-	}
-	if resp.BrowseNodesResult.BrowseNodes[0].SalesRank == nil {
-		t.Fatal("BrowseNodes[0].SalesRank is nil")
-	}
-	if got, want := *resp.BrowseNodesResult.BrowseNodes[0].SalesRank, 11; got != want {
-		t.Errorf("BrowseNodes[0].SalesRank = %d, want %d", got, want)
+	if got, want := vs.VariationDimensions[0].Name, "color_name"; got != want {
+		t.Errorf("VariationDimensions[0].Name = %q, want %q", got, want)
 	}
 }

--- a/query/getitems_test.go
+++ b/query/getitems_test.go
@@ -85,8 +85,8 @@ func TestResourcesInGetItems(t *testing.T) {
 		q   *GetItems
 		str string
 	}{
-		{q: NewGetItems("", "", "").EnableBrowseNodeInfo(), str: `{"resources":["browseNodeInfo.browseNodes","browseNodeInfo.browseNodes.ancestor","browseNodeInfo.browseNodes.salesRank","browseNodeInfo.websiteSalesRank"]}`},
-		{q: NewGetItems("", "", "").EnableImages(), str: `{"resources":["images.primary.small","images.primary.medium","images.primary.large","images.primary.highRes","images.variants.small","images.variants.medium","images.variants.large","images.variants.highRes"]}`},
+		{q: NewGetItems("", "", "").EnableBrowseNodeInfo(), str: `{"resources":["browseNodeInfo.browseNodes","browseNodeInfo.browseNodes.ancestor","browseNodeInfo.websiteSalesRank"]}`},
+		{q: NewGetItems("", "", "").EnableImages(), str: `{"resources":["images.primary.small","images.primary.medium","images.primary.large","images.variants.small","images.variants.medium","images.variants.large"]}`},
 		{q: NewGetItems("", "", "").EnableItemInfo(), str: `{"resources":["itemInfo.byLineInfo","itemInfo.contentInfo","itemInfo.contentRating","itemInfo.classifications","itemInfo.externalIds","itemInfo.features","itemInfo.manufactureInfo","itemInfo.productInfo","itemInfo.technicalInfo","itemInfo.title","itemInfo.tradeInInfo"]}`},
 		// EnableOffers (V1) is now an alias for EnableOffersV2.
 		{q: NewGetItems("", "", "").EnableOffers(), str: `{"resources":["offersV2.listings.availability","offersV2.listings.condition","offersV2.listings.dealDetails","offersV2.listings.isBuyBoxWinner","offersV2.listings.loyaltyPoints","offersV2.listings.merchantInfo","offersV2.listings.price","offersV2.listings.type"]}`},

--- a/query/getvariations_test.go
+++ b/query/getvariations_test.go
@@ -87,8 +87,8 @@ func TestResourcesInGetVariations(t *testing.T) {
 		q   *GetVariations
 		str string
 	}{
-		{q: NewGetVariations("", "", "").EnableBrowseNodeInfo(), str: `{"resources":["browseNodeInfo.browseNodes","browseNodeInfo.browseNodes.ancestor","browseNodeInfo.browseNodes.salesRank","browseNodeInfo.websiteSalesRank"]}`},
-		{q: NewGetVariations("", "", "").EnableImages(), str: `{"resources":["images.primary.small","images.primary.medium","images.primary.large","images.primary.highRes","images.variants.small","images.variants.medium","images.variants.large","images.variants.highRes"]}`},
+		{q: NewGetVariations("", "", "").EnableBrowseNodeInfo(), str: `{"resources":["browseNodeInfo.browseNodes","browseNodeInfo.browseNodes.ancestor","browseNodeInfo.websiteSalesRank"]}`},
+		{q: NewGetVariations("", "", "").EnableImages(), str: `{"resources":["images.primary.small","images.primary.medium","images.primary.large","images.variants.small","images.variants.medium","images.variants.large"]}`},
 		{q: NewGetVariations("", "", "").EnableItemInfo(), str: `{"resources":["itemInfo.byLineInfo","itemInfo.contentInfo","itemInfo.contentRating","itemInfo.classifications","itemInfo.externalIds","itemInfo.features","itemInfo.manufactureInfo","itemInfo.productInfo","itemInfo.technicalInfo","itemInfo.title","itemInfo.tradeInInfo"]}`},
 		{q: NewGetVariations("", "", "").EnableOffers(), str: `{"resources":["offersV2.listings.availability","offersV2.listings.condition","offersV2.listings.dealDetails","offersV2.listings.isBuyBoxWinner","offersV2.listings.loyaltyPoints","offersV2.listings.merchantInfo","offersV2.listings.price","offersV2.listings.type"]}`},
 		{q: NewGetVariations("", "", "").EnableOffersV2(), str: `{"resources":["offersV2.listings.availability","offersV2.listings.condition","offersV2.listings.dealDetails","offersV2.listings.isBuyBoxWinner","offersV2.listings.loyaltyPoints","offersV2.listings.merchantInfo","offersV2.listings.price","offersV2.listings.type"]}`},

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -130,8 +130,8 @@ func TestResources(t *testing.T) {
 		q   *Query
 		str string
 	}{
-		{q: empty.With().BrowseNodeInfo(), str: `{"resources":["browseNodeInfo.browseNodes","browseNodeInfo.browseNodes.ancestor","browseNodeInfo.browseNodes.salesRank","browseNodeInfo.websiteSalesRank"]}`},
-		{q: empty.With().Images(), str: `{"resources":["images.primary.small","images.primary.medium","images.primary.large","images.primary.highRes","images.variants.small","images.variants.medium","images.variants.large","images.variants.highRes"]}`},
+		{q: empty.With().BrowseNodeInfo(), str: `{"resources":["browseNodeInfo.browseNodes","browseNodeInfo.browseNodes.ancestor","browseNodeInfo.websiteSalesRank"]}`},
+		{q: empty.With().Images(), str: `{"resources":["images.primary.small","images.primary.medium","images.primary.large","images.variants.small","images.variants.medium","images.variants.large"]}`},
 		{q: empty.With().ItemInfo(), str: `{"resources":["itemInfo.byLineInfo","itemInfo.contentInfo","itemInfo.contentRating","itemInfo.classifications","itemInfo.externalIds","itemInfo.features","itemInfo.manufactureInfo","itemInfo.productInfo","itemInfo.technicalInfo","itemInfo.title","itemInfo.tradeInInfo"]}`},
 		// Offers (V1) is now an alias for OffersV2 in the Creators API.
 		{q: empty.With().Offers(), str: `{"resources":["offersV2.listings.availability","offersV2.listings.condition","offersV2.listings.dealDetails","offersV2.listings.isBuyBoxWinner","offersV2.listings.loyaltyPoints","offersV2.listings.merchantInfo","offersV2.listings.price","offersV2.listings.type"]}`},

--- a/query/resources.go
+++ b/query/resources.go
@@ -15,13 +15,12 @@ const (
 )
 
 // Resource string values match the Amazon Creators API enum values
-// (lowerCamelCase). Sourced from the official Amazon Creators API SDK.
+// (lowerCamelCase), scoped to shapes documented for Creators API catalog ops.
 var (
 	//BrowseNodeInfo resource
 	resourcesBrowseNodeInfo = []string{
 		"browseNodeInfo.browseNodes",
 		"browseNodeInfo.browseNodes.ancestor",
-		"browseNodeInfo.browseNodes.salesRank",
 		"browseNodeInfo.websiteSalesRank",
 	}
 	//Images resource
@@ -29,11 +28,9 @@ var (
 		"images.primary.small",
 		"images.primary.medium",
 		"images.primary.large",
-		"images.primary.highRes",
 		"images.variants.small",
 		"images.variants.medium",
 		"images.variants.large",
-		"images.variants.highRes",
 	}
 	//ItemInfo resource
 	resourcesItemInfo = []string{

--- a/query/searchitems_test.go
+++ b/query/searchitems_test.go
@@ -123,8 +123,8 @@ func TestResourcesInSearchItems(t *testing.T) {
 		q   *SearchItems
 		str string
 	}{
-		{q: NewSearchItems("", "", "").EnableBrowseNodeInfo(), str: `{"resources":["browseNodeInfo.browseNodes","browseNodeInfo.browseNodes.ancestor","browseNodeInfo.browseNodes.salesRank","browseNodeInfo.websiteSalesRank"]}`},
-		{q: NewSearchItems("", "", "").EnableImages(), str: `{"resources":["images.primary.small","images.primary.medium","images.primary.large","images.primary.highRes","images.variants.small","images.variants.medium","images.variants.large","images.variants.highRes"]}`},
+		{q: NewSearchItems("", "", "").EnableBrowseNodeInfo(), str: `{"resources":["browseNodeInfo.browseNodes","browseNodeInfo.browseNodes.ancestor","browseNodeInfo.websiteSalesRank"]}`},
+		{q: NewSearchItems("", "", "").EnableImages(), str: `{"resources":["images.primary.small","images.primary.medium","images.primary.large","images.variants.small","images.variants.medium","images.variants.large"]}`},
 		{q: NewSearchItems("", "", "").EnableItemInfo(), str: `{"resources":["itemInfo.byLineInfo","itemInfo.contentInfo","itemInfo.contentRating","itemInfo.classifications","itemInfo.externalIds","itemInfo.features","itemInfo.manufactureInfo","itemInfo.productInfo","itemInfo.technicalInfo","itemInfo.title","itemInfo.tradeInInfo"]}`},
 		{q: NewSearchItems("", "", "").EnableOffers(), str: `{"resources":["offersV2.listings.availability","offersV2.listings.condition","offersV2.listings.dealDetails","offersV2.listings.isBuyBoxWinner","offersV2.listings.loyaltyPoints","offersV2.listings.merchantInfo","offersV2.listings.price","offersV2.listings.type"]}`},
 		{q: NewSearchItems("", "", "").EnableOffersV2(), str: `{"resources":["offersV2.listings.availability","offersV2.listings.condition","offersV2.listings.dealDetails","offersV2.listings.isBuyBoxWinner","offersV2.listings.loyaltyPoints","offersV2.listings.merchantInfo","offersV2.listings.price","offersV2.listings.type"]}`},


### PR DESCRIPTION
## Context

Follow-up to the split discussed in [#49](https://github.com/goark/pa-api/pull/49): [#50](https://github.com/goark/pa-api/pull/50) merged PR‑A (safe migration fixes). This PR is **PR‑B**: contract tightening—drop struct fields and resource strings that are not documented / not relied on for Creators API catalog responses.

## Changes

### Entity (`entity/entity.go`)

- Remove `Item.Score`.
- Remove `Images.Primary` / `Images.Variants` `HiRes` decode targets.
- Remove `browseNodeInfo.browseNodes[].salesRank` and `websiteSalesRank.id` from the nested browse-node shape; keep `websiteSalesRank` fields that match published shapes.
- Remove `VariationDimension.Locale`.
- Remove top-level `browseNodesResult.browseNodes[].salesRank`.

### Resources (`query/resources.go`)

- Stop requesting `browseNodeInfo.browseNodes.salesRank`.
- Stop requesting `images.primary.highRes` and `images.variants.highRes`.

### Tests

- Refresh `entity` decode fixtures/assertions and all `query` resource JSON expectations.

## Intentionally unchanged (from #50)

- `OffersV2.Listings[].ViolatesMAP` with `json:"violatesMAP,omitempty"` remains—the API returns `violatesMAP` and decode must match.

## Verification

`gofmt -w …` and `go test ./...`