### PR TITLE
Add govulncheck task and align Go 1.25.10 baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A Go client for [Amazon's Creators API][creatorsapi-docs], the OAuth2-based replacement for the now-retired Product Advertising API v5 (PA-API). The package keeps the import path `github.com/goark/pa-api` and the package name `paapi5` so existing call sites need only minor changes; under the hood the wire protocol, authentication and host all change.
 
-This package requires Go 1.25 or later.
+This package requires Go 1.25.10 or later.
 
 ### Go version policy
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5,6 +5,7 @@ tasks:
     cmds:
       - task: prepare
       - task: test
+      - task: govulncheck
       # - task: nancy
 
   test:
@@ -13,6 +14,14 @@ tasks:
       - go mod verify
       - go test -shuffle on ./...
       - golangci-lint-v2 run --enable gosec --timeout 3m0s ./...
+    sources:
+      - ./go.mod
+      - '**/*.go'
+
+  govulncheck:
+    desc: Check reachable vulnerabilities with latest govulncheck.
+    cmds:
+      - go run golang.org/x/vuln/cmd/govulncheck@latest ./...
     sources:
       - ./go.mod
       - '**/*.go'
@@ -26,7 +35,8 @@ tasks:
       - '**/*.go'
 
   prepare:
-      - go mod tidy -v -go=1.25
+    cmds:
+      - go mod tidy -v -go=1.25.10
 
   clean:
     desc: Initialize module and build cache, and remake go.sum file.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/goark/pa-api
 
-go 1.25
+go 1.25.10
 
 require (
 	github.com/goark/errs v1.3.2


### PR DESCRIPTION
## Summary
- add a dedicated Task task: govulncheck (latest govulncheck)
- include govulncheck in the default task flow
- update go.mod directive to Go 1.25.10
- align README minimum Go version text
- align prepare task to go mod tidy -go=1.25.10

## Validation
- task -f test
- task -f govulncheck
