### PR TITLE
Fix entity tag

### DIFF
--- a/entity/entity.go
+++ b/entity/entity.go
@@ -333,7 +333,7 @@ type Response struct {
 	} `json:",omitempty"`
 	ItemsResult *struct {
 		Items []Item `json:",omitempty"`
-	} `json:"itemResults,omitempty"`
+	} `json:"itemsResult,omitempty"`
 	SearchResult *struct {
 		Items             []Item `json:",omitempty"`
 		SearchRefinements *struct {

--- a/entity/entity_test.go
+++ b/entity/entity_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestDecodeResponseItemResultsAndCreatorsFields(t *testing.T) {
 	body := []byte(`{
-  "itemResults": {
+  "itemsResult": {
     "items": [
       {
         "asin": "A1",


### PR DESCRIPTION
There is a typo in Amazon's documentation. Currently responses are not decoding correctly because of this. The [GetItems docs](https://affiliate-program.amazon.com/creatorsapi/docs/en-us/api-reference/operations/get-items) explain the payload is returned in the `itemResults` tag, but it is actually still `itemsResults`.